### PR TITLE
Run ansible from docker via ssh tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# SSH Connection Configuration
+HOST_A_USER=ansible_user
+HOST_A_IP=192.168.1.100
+HOST_B_USER=tunnel_user
+HOST_B_IP=192.168.1.50
+ANSIBLE_BASE_PATH=/home/ansible_user/ansible
+
+# Optional: If you need to customize SSH key location
+# SSH_KEY_PATH=/app/ssh_keys/id_rsa


### PR DESCRIPTION
Implement a FastAPI application in Docker to run Ansible on a remote host (Host A) via an SSH tunnel through a jump host (Host B).

---

[Open in Web](https://cursor.com/agents?id=bc-40ba5303-18ab-47a8-b97f-5d7225b5ca93) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-40ba5303-18ab-47a8-b97f-5d7225b5ca93) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)